### PR TITLE
Add .npmignore file to reduce npm package by 90%

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+docs/
+demo/


### PR DESCRIPTION
This repo publishes a package to NPM manually (using `npm publish` on the local command line). As a result the publish step will generate and push a tarball which only excludes files determined by the `.gitignore` file, resulting in a package sized 33.0MB (56.7MB unpacked). The package includes all the files in the `docs` and `demo` folders:

<img width="658" alt="Screenshot 2023-11-26 at 20 37 19" src="https://github.com/KaliedaRik/Scrawl-canvas/assets/5357530/3c1601b2-7367-488e-91cf-d6fb292365ab">

Developers do not need the documentation and demos when all they want to do is include Scrawl-canvas in their projects. This PR adds an `.npmignore` file to exclude these folders from the publish step. The resulting package size is 1.8MB (5.6MB unpacked):

<img width="518" alt="Screenshot 2023-11-26 at 20 34 32" src="https://github.com/KaliedaRik/Scrawl-canvas/assets/5357530/b1a6e9b4-3cb3-4f12-a6db-64a1dc9a563a">

