### PR TITLE
Add star-history chart to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,8 +185,9 @@ $> yarn build
 ```
 
 ### Star-history
-<iframe style="width:100%;height:auto;min-width:600px;min-height:400px;" src="https://star-history.com/embed?secret=Z2hwXzFlQ0paZ0JSSEZlRFhNYk5nMzVORWVHSnZnZ1VCRzI3cFRMNw==#KaliedaRik/Scrawl-canvas&Date" frameBorder="0"></iframe>
+![star-history-20231230](https://github.com/KaliedaRik/Scrawl-canvas/assets/5357530/3ce12e96-239c-49c2-8ff9-35f7610c4766)
 
+[See the live chart on the Star-history site](https://star-history.com/#KaliedaRik/Scrawl-canvas&Date)
 
 ### Development team
 Developed by Rik Roots: rik.roots@rikworks.co.uk

--- a/README.md
+++ b/README.md
@@ -184,6 +184,9 @@ Running the following command on the command line will recreate the minified fil
 $> yarn build
 ```
 
+### Star-history
+<iframe style="width:100%;height:auto;min-width:600px;min-height:400px;" src="https://star-history.com/embed?secret=Z2hwXzFlQ0paZ0JSSEZlRFhNYk5nMzVORWVHSnZnZ1VCRzI3cFRMNw==#KaliedaRik/Scrawl-canvas&Date" frameBorder="0"></iframe>
+
 
 ### Development team
 Developed by Rik Roots: rik.roots@rikworks.co.uk


### PR DESCRIPTION
I want to add this star-history chart to the README: https://star-history.com/#KaliedaRik/Scrawl-canvas&Date

![star-history-20231230](https://github.com/KaliedaRik/Scrawl-canvas/assets/5357530/57e7718c-435a-4081-99e8-c5bf959c929a)
