### PR TITLE
Separate workstore from filter engine

### DIFF
--- a/demo/filters-028.js
+++ b/demo/filters-028.js
@@ -52,6 +52,23 @@ scrawl.makePicture({
     method: 'none',
 });
 
+// Gradient
+scrawl.makeGradient({
+
+    name: name('gradient'),
+    endX: '100%',
+
+    colors: [
+        [0, 'blue'],
+        [350, 'red'],
+        [500, 'transparent'],
+        [649, 'red'],
+        [999, 'green']
+    ],
+    colorSpace: 'OKLAB',
+    precision: 5,
+});
+
 // __Displace__ filter
 scrawl.makeFilter({
     name: name('displace'),
@@ -572,7 +589,8 @@ const cog = scrawl.makeCog({
     outerControlsDistance: 20,
     innerControlsDistance: 16,
     points: 12,
-    fillStyle: 'red',
+    fillStyle: name('gradient'),
+    lockFillStyleToEntity: true,
     delta: {
         roll: 0.5,
     },
@@ -751,7 +769,7 @@ scrawl.makeUpdater({
     event: ['change'],
     origin: '.controlItem',
 
-    target: stencil,
+    target: group,
 
     useNativeListener: true,
     preventDefault: true,

--- a/source/core/workstore.js
+++ b/source/core/workstore.js
@@ -105,6 +105,6 @@ const purgeWorkstore = () => {
 makeAnimation({
 
     name: 'core-workstore-hygeine',
-    order: 0,
+    order: 998,
     fn: () => purgeWorkstore(),
 });

--- a/source/core/workstore.js
+++ b/source/core/workstore.js
@@ -1,0 +1,110 @@
+// # Workstore
+
+import { makeAnimation } from '../factory/animation.js';
+import { _keys, _now } from './shared-vars.js';
+
+
+// `workstore`, `workstoreLastAccessed` - Scrawl-canvas maintains a semi-permanent storage space for some processing objects that are computationally expensive, for instance grids, matrix reference data objects, etc. The engine also maintains a record of when each of these processing objects was last accessed and will remove objects if they have not been accessed in the last three seconds.
+export const workstore = {};
+export const workstoreLastAccessed = {};
+
+// `choke` - measure in milliseconds before an entry in the workstore goes stale and gets removed from the workstore
+let lifetimeLength = 1000;
+
+// `setWorkstoreLifetimeLength`
+export const setWorkstoreLifetimeLength = (val) => {
+
+    if (val.toFixed && !isNaN(val) && val >= 200 && val <= 10000) lifetimeLength = val;
+};
+
+// `setFilterMemoizationChoke` - DEPRECATED in favour of `setWorkstoreLifetimeLength`
+export const setFilterMemoizationChoke = (val) => {
+
+    if (val.toFixed && !isNaN(val) && val >= 200 && val <= 10000) lifetimeLength = val;
+};
+
+// `getWorkstoreItem`, `setWorkstoreItem` - retrieve, or set, the value stored at the identifier key
+export const getWorkstoreItem = (identifier) => {
+
+    if (workstore[identifier]) {
+
+        workstoreLastAccessed[identifier] = _now();
+        return workstore[identifier];
+    }
+    return null;
+};
+
+export const setWorkstoreItem = (identifier, value) => {
+
+    workstore[identifier] = value;
+    workstoreLastAccessed[identifier] = _now();
+};
+
+// `getOrAddWorkstoreItem` - retrieves the value stored at the identifier key. If the key does not exist, create and populate it with the value array/object, then return that value;
+export const getOrAddWorkstoreItem = function (identifier, value = []) {
+
+    const now = _now();
+
+    if (workstore[identifier]) {
+
+        workstoreLastAccessed[identifier] = now;
+        return workstore[identifier];
+    }
+
+    workstore[identifier] = value;
+    workstoreLastAccessed[identifier] = now;
+    return workstore[identifier];
+};
+
+// `setAndReturnWorkstoreItem` - create or set the value stored at the identifier key, then return that value;
+export const setAndReturnWorkstoreItem = function (identifier, value = []) {
+
+    workstore[identifier] = value;
+    workstoreLastAccessed[identifier] = _now();
+    return workstore[identifier];
+};
+
+
+// #### Workstore hygeine
+// `purgeChoke`, `purgeLastPerformed` - minimum time between purge runs, and when the last purge took place
+let purgeChoke = 200;
+let purgeLastPerformed = 0;
+
+// `setWorkstorePurgeChoke`
+export const setWorkstorePurgeChoke = (val) => {
+
+    if (val.toFixed && !isNaN(val) && val >= 10 && val <= 5000) purgeChoke = val;
+};
+
+// `purgeWorkstore` - internal function
+const purgeWorkstore = () => {
+
+    const now = _now(),
+        choke = now - purgeChoke;
+
+    if (purgeLastPerformed < choke) {
+
+        const workstoreKeys = _keys(workstore),
+            workstoreChoke = now - lifetimeLength;
+
+        for (let i = 0, iz = workstoreKeys.length, s; i < iz; i++) {
+
+            s = workstoreKeys[i];
+
+            if (workstoreLastAccessed[s] < workstoreChoke) {
+
+                delete workstore[s];
+                delete workstoreLastAccessed[s];
+            }
+        }
+        purgeLastPerformed = now;
+    }
+};
+
+// `coreWorkstoreHygeine` animation object runs every RAF cycle
+makeAnimation({
+
+    name: 'coreWorkstoreHygeine',
+    order: 0,
+    fn: () => purgeWorkstore(),
+});

--- a/source/core/workstore.js
+++ b/source/core/workstore.js
@@ -4,11 +4,11 @@ import { makeAnimation } from '../factory/animation.js';
 import { _keys, _now } from './shared-vars.js';
 
 
-// `workstore`, `workstoreLastAccessed` - Scrawl-canvas maintains a semi-permanent storage space for some processing objects that are computationally expensive, for instance grids, matrix reference data objects, etc. The engine also maintains a record of when each of these processing objects was last accessed and will remove objects if they have not been accessed in the last three seconds.
-export const workstore = {};
-export const workstoreLastAccessed = {};
+// `workstore`, `workstoreLastAccessed` - Scrawl-canvas maintains a semi-permanent storage space for some processing objects that are computationally expensive, for instance grids, matrix reference data objects, etc. The engine also maintains a record of when each of these processing objects was last accessed and will remove objects if they have not been accessed in the last few seconds.
+const workstore = {};
+const workstoreLastAccessed = {};
 
-// `choke` - measure in milliseconds before an entry in the workstore goes stale and gets removed from the workstore
+// `lifetimeLength` - measure in milliseconds before an entry in the workstore goes stale and gets removed from the workstore
 let lifetimeLength = 1000;
 
 // `setWorkstoreLifetimeLength`
@@ -101,10 +101,10 @@ const purgeWorkstore = () => {
     }
 };
 
-// `coreWorkstoreHygeine` animation object runs every RAF cycle
+// `core-workstore-hygeine` animation object runs every RAF cycle
 makeAnimation({
 
-    name: 'coreWorkstoreHygeine',
+    name: 'core-workstore-hygeine',
     order: 0,
     fn: () => purgeWorkstore(),
 });

--- a/source/factory/conic-gradient.js
+++ b/source/factory/conic-gradient.js
@@ -7,11 +7,6 @@
 // ConicGradients can be applied to an entity in two different ways, depending on the entity's `lockFillStyleToEntity` and `lockStrokeStyleToEntity` attribute flags:
 // + __Cell-locked__ ConicGradients will cover the entire Cell; an entity moved from one part of the display to another will show different parts of the gradient
 // + __Entity-locked__ ConicGradients display their entire color range on the entity, move with the entity and even rotate with the entity.
-//
-// __TO NOTE: _this is an experimental technology; most browsers do not (yet) support conic gradients for canvases, only in CSS.___ In these browsers, the gradient will return a solid, transparent color. To see the effect, enable the appropriate flags in the browser:
-// + Chrome browsers< - from version 86: this feature is behind the #new-canvas-2d-api preferences. To change preferences in Chrome, visit chrome://flags
-// + Firefox browsers - From version 86: this feature is behind the canvas.createConicGradient.enabled preferences. To change preferences in Firefox, visit about:config
-// + Other browsers - currently no signals about support. See the MDN createConicGradient() page for further details
 
 
 // #### Demos:

--- a/source/factory/filter-engine.js
+++ b/source/factory/filter-engine.js
@@ -1051,6 +1051,8 @@ P.getGradientData = function (gradient) {
 
     if (!itemInWorkstore || gradient.dirtyFilterIdentifier || gradient.animateByDelta) {
 
+        const palette = gradient.palette;
+
         const mycell = requestCell();
 
         const {engine, element} = mycell;
@@ -1058,7 +1060,8 @@ P.getGradientData = function (gradient) {
         element.width = 256;
         element.height = 1;
 
-        gradient.palette.recalculateStopColors();
+        palette.dirtyPaletteData = true;
+        if (palette.dirtyPalette) palette.recalculateStopColors();
 
         const G = engine.createLinearGradient(0, 0, 255, 0);
 

--- a/source/factory/filter-engine.js
+++ b/source/factory/filter-engine.js
@@ -1051,17 +1051,12 @@ P.getGradientData = function (gradient) {
 
     if (!itemInWorkstore || gradient.dirtyFilterIdentifier || gradient.animateByDelta) {
 
-        const palette = gradient.palette;
-
         const mycell = requestCell();
 
         const {engine, element} = mycell;
 
         element.width = 256;
         element.height = 1;
-
-        palette.dirtyPaletteData = true;
-        if (palette.dirtyPalette) palette.recalculateStopColors();
 
         const G = engine.createLinearGradient(0, 0, 255, 0);
 

--- a/source/factory/filter-engine.js
+++ b/source/factory/filter-engine.js
@@ -23,7 +23,7 @@ import { makeColor } from './color.js';
 
 import { bluenoise } from './filter-engine-bluenoise-data.js';
 
-import { _abs, _ceil, _entries, _exp, _floor, _freeze, _isArray, _keys, _max, _min, _now, _round, _sqrt, ALPHA_TO_CHANNELS, AREA_ALPHA, ARG_SPLITTER, AVERAGE_CHANNELS, BLACK_WHITE, BLEND, BLUE, BLUENOISE, BLUR, CHANNELS_TO_ALPHA, CHROMA, CLAMP_CHANNELS, CLEAR, COLOR, COLOR_BURN, COLOR_DODGE, COLORS_TO_ALPHA, COMPOSE, CORRODE, CURRENT, DARKEN, DEFAULT_SEED, DESTINATION_ATOP, DESTINATION_IN, DESTINATION_ONLY, DESTINATION_OUT, DESTINATION_OVER, DIFFERENCE, DISPLACE, DOWN, EMBOSS, EXCLUSION, FLOOD, GAUSSIAN_BLUR, GLITCH, GRAY_PALETTES, GRAYSCALE, GREEN, HARD_LIGHT, HEX_GRID, HUE, INVERT_CHANNELS, LIGHTEN, LIGHTER, LOCK_CHANNELS_TO_LEVELS, LUMINOSITY, MAP_TO_GRADIENT, MATRIX, MEAN, MODULATE_CHANNELS, MONOCHROME_16, MONOCHROME_4, MONOCHROME_8, MULTIPLY, NEWSPRINT, OFFSET, ORDERED, OVERLAY, PIXELATE, POINTS_ARRAY, PROCESS_IMAGE, RANDOM, RANDOM_NOISE, RANDOM_POINTS, RECT_GRID, RED, REDUCE_PALETTE, ROUND, SATURATION, SCREEN, SET_CHANNEL_TO_LEVEL, SOFT_LIGHT, SOURCE, SOURCE_ALPHA, SOURCE_ATOP, SOURCE_IN, SOURCE_ONLY, SOURCE_OUT, STEP_CHANNELS, SWIRL, T_FILTER_ENGINE, THRESHOLD, TILES, TINT_CHANNELS, UNSET, UP, USER_DEFINED_LEGACY, VARY_CHANNELS_BY_WEIGHTS, XOR, ZERO_STR } from '../core/shared-vars.js';
+import { _abs, _ceil, _entries, _exp, _floor, _freeze, _isArray, _max, _min, _round, _sqrt, ALPHA_TO_CHANNELS, AREA_ALPHA, ARG_SPLITTER, AVERAGE_CHANNELS, BLACK_WHITE, BLEND, BLUE, BLUENOISE, BLUR, CHANNELS_TO_ALPHA, CHROMA, CLAMP_CHANNELS, CLEAR, COLOR, COLOR_BURN, COLOR_DODGE, COLORS_TO_ALPHA, COMPOSE, CORRODE, CURRENT, DARKEN, DEFAULT_SEED, DESTINATION_ATOP, DESTINATION_IN, DESTINATION_ONLY, DESTINATION_OUT, DESTINATION_OVER, DIFFERENCE, DISPLACE, DOWN, EMBOSS, EXCLUSION, FLOOD, GAUSSIAN_BLUR, GLITCH, GRAY_PALETTES, GRAYSCALE, GREEN, HARD_LIGHT, HEX_GRID, HUE, INVERT_CHANNELS, LIGHTEN, LIGHTER, LOCK_CHANNELS_TO_LEVELS, LUMINOSITY, MAP_TO_GRADIENT, MATRIX, MEAN, MODULATE_CHANNELS, MONOCHROME_16, MONOCHROME_4, MONOCHROME_8, MULTIPLY, NEWSPRINT, OFFSET, ORDERED, OVERLAY, PIXELATE, POINTS_ARRAY, PROCESS_IMAGE, RANDOM, RANDOM_NOISE, RANDOM_POINTS, RECT_GRID, RED, REDUCE_PALETTE, ROUND, SATURATION, SCREEN, SET_CHANNEL_TO_LEVEL, SOFT_LIGHT, SOURCE, SOURCE_ALPHA, SOURCE_ATOP, SOURCE_IN, SOURCE_ONLY, SOURCE_OUT, STEP_CHANNELS, SWIRL, T_FILTER_ENGINE, THRESHOLD, TILES, TINT_CHANNELS, UNSET, UP, USER_DEFINED_LEGACY, VARY_CHANNELS_BY_WEIGHTS, XOR, ZERO_STR } from '../core/shared-vars.js';
 
 
 // Local constants
@@ -78,7 +78,7 @@ P.action = function (packet) {
 
     const { identifier, filters, image } = packet;
     const { actions, theBigActionsObject } = this;
-    let i, iz, s, actData, a;
+    let i, iz, actData, a;
 
     const itemInWorkstore = getWorkstoreItem(identifier);
     if (itemInWorkstore) return itemInWorkstore;
@@ -679,7 +679,7 @@ P.buildGeneralTileSets = function (pointVals, tileWidth, tileHeight, tileRadius,
                 points = getWorkstoreItem(pointsName);
 
                 if (!points) {
-                
+
                     // User-generated points are not pre-processed. Note that the positioning of these points is relative to the offset coordinate values; users, when generating the point values, need to take this into account otherwise the end result may unexpectedly move towards (or beyond) the bottom-right part of the final image.
                     const newPoints = [...pointVals];
 

--- a/source/factory/filter-engine.js
+++ b/source/factory/filter-engine.js
@@ -209,7 +209,6 @@ P.buildImageGrid = function (image) {
         _freeze(grid);
         setWorkstoreItem(name, grid);
         return grid;
-
     }
     return false;
 };
@@ -1059,7 +1058,7 @@ P.getGradientData = function (gradient) {
         element.width = 256;
         element.height = 1;
 
-        gradient.palette.recalculate();
+        gradient.palette.recalculateStopColors();
 
         const G = engine.createLinearGradient(0, 0, 255, 0);
 

--- a/source/factory/filter-engine.js
+++ b/source/factory/filter-engine.js
@@ -9,6 +9,8 @@ import { seededRandomNumberGenerator } from '../core/random-seed.js';
 
 import { correctAngle, doCreate, easeEngines, isa_fn } from '../core/utilities.js';
 
+import { getOrAddWorkstoreItem, getWorkstoreItem, setAndReturnWorkstoreItem, setWorkstoreItem } from '../core/workstore.js';
+
 import { makeAnimation } from './animation.js';
 
 import { releaseCell, requestCell } from './cell-fragment.js';
@@ -72,39 +74,14 @@ const FilterEngine = function () {
 const P = FilterEngine.prototype = doCreate();
 P.type = T_FILTER_ENGINE;
 
-let choke = 1000;
-export const setFilterMemoizationChoke = function (val) {
-
-    if (val.toFixed && !isNaN(val) && val >= 200 && val <= 10000) choke = val;
-};
-
 P.action = function (packet) {
 
     const { identifier, filters, image } = packet;
-
-    const { workstoreLastAccessed, workstore, actions, theBigActionsObject } = this;
-
-    const workstoreKeys = _keys(workstore),
-        workstoreChoke = _now() - choke;
-
+    const { actions, theBigActionsObject } = this;
     let i, iz, s, actData, a;
 
-    for (i = 0, iz = workstoreKeys.length, s; i < iz; i++) {
-
-        s = workstoreKeys[i];
-
-        if (workstoreLastAccessed[s] < workstoreChoke) {
-
-            delete workstore[s];
-            delete workstoreLastAccessed[s];
-        }
-    }
-
-    if (identifier && workstore[identifier]) {
-
-        workstoreLastAccessed[identifier] = _now();
-        return workstore[identifier];
-    }
+    const itemInWorkstore = getWorkstoreItem(identifier);
+    if (itemInWorkstore) return itemInWorkstore;
 
     actions.length = 0;
 
@@ -127,11 +104,7 @@ P.action = function (packet) {
             if (a) a.call(this, actData);
         }
 
-        if (identifier) {
-
-            workstore[identifier] = this.cache.work;
-            workstoreLastAccessed[identifier] = _now();
-        }
+        if (identifier) setWorkstoreItem(identifier, this.cache.work);
 
         return this.cache.work;
     }
@@ -140,10 +113,6 @@ P.action = function (packet) {
 
 
 // ### Permanent variables
-
-// The filter engine maintains a semi-permanent storage space - the __workstore__ - for some processing objects that are computationally expensive, for instance grids, matrix reference data objects, etc. The engine also maintains a record of when each of these processing objects was last accessed and will remove objects if they have not been accessed in the last three seconds.
-P.workstore = {};
-P.workstoreLastAccessed = {};
 
 // ColorSpaceIndices are used by the reducePalette filter. Hoping to expand this to other filters to allow a wider use of OKLAB/OKLCH color spaces.
 P.colorSpaceIndices = function () {
@@ -207,7 +176,7 @@ P.getAlphaData = function (image) {
 // `buildImageGrid` creates an Array of Arrays which contain the indexes of each pixel in the image channel Arrays
 P.buildImageGrid = function (image) {
 
-    const { cache, workstore, workstoreLastAccessed } = this;
+    const { cache } = this;
 
     if (!image) image = cache.source;
 
@@ -215,11 +184,10 @@ P.buildImageGrid = function (image) {
 
     if (width && height) {
 
-        const name = `grid-${width}-${height}`;
-        if (workstore[name]) {
-            workstoreLastAccessed[name] = _now();
-            return workstore[name];
-        }
+        const name = `grid-${width}-${height}`,
+            itemInWorkstore = getWorkstoreItem(name);
+
+        if (itemInWorkstore) return itemInWorkstore;
 
         const grid = [];
 
@@ -237,26 +205,13 @@ P.buildImageGrid = function (image) {
             }
             grid.push(_freeze(row));
         }
-        workstore[name] = _freeze(grid);
-        workstoreLastAccessed[name] = _now();
-        return workstore[name];
+
+        _freeze(grid);
+        setWorkstoreItem(name, grid);
+        return grid;
+
     }
     return false;
-};
-
-// `getOrAddWorkstore` creates an Array which can be populated by swirl-related coordinates
-P.getOrAddWorkstore = function (name) {
-
-    const { workstore, workstoreLastAccessed } = this;
-
-    if (workstore[name]) {
-        workstoreLastAccessed[name] = _now();
-        return workstore[name];
-    }
-
-    workstore[name] = [];
-    workstoreLastAccessed[name] = _now();
-    return workstore[name];
 };
 
 P.getRandomNumbers = function (items = {}) {
@@ -268,14 +223,10 @@ P.getRandomNumbers = function (items = {}) {
         type = RANDOM,
     } = items;
 
-    const name = `random-${seed}-${length}-${type}`;
+    const name = `random-${seed}-${length}-${type}`,
+        itemInWorkstore = getWorkstoreItem(name);
 
-    const { workstore, workstoreLastAccessed } = this;
-
-    if (workstore[name]) {
-        workstoreLastAccessed[name] = _now();
-        return workstore[name];
-    }
+    if (itemInWorkstore) return itemInWorkstore;
 
     const vals = requestArray();
 
@@ -347,17 +298,16 @@ P.getRandomNumbers = function (items = {}) {
         }
     }
 
-    workstore[name] = new Float32Array(vals);
-    workstoreLastAccessed[name] = _now();
-
+    const valsArray = new Float32Array(vals);
     releaseArray(vals);
 
-    return workstore[name];
+    setWorkstoreItem(name, valsArray);
+    return valsArray;
 };
 
 P.buildImageCoordinateLookup = function (image) {
 
-    const { cache, workstore, workstoreLastAccessed } = this;
+    const { cache } = this;
 
     if (!image) image = cache.source;
 
@@ -365,12 +315,10 @@ P.buildImageCoordinateLookup = function (image) {
 
     if (width && height) {
 
-        const name = `coords-lookup-${width}-${height}`;
+        const name = `coords-lookup-${width}-${height}`,
+            itemInWorkstore = getWorkstoreItem(name);
 
-        if (workstore[name]) {
-            workstoreLastAccessed[name] = _now();
-            return workstore[name];
-        }
+        if (itemInWorkstore) return itemInWorkstore;
 
         const lookup = []
 
@@ -381,9 +329,10 @@ P.buildImageCoordinateLookup = function (image) {
                 lookup.push(_freeze([x, y]));
             }
         }
-        workstore[name] = _freeze(lookup);
-        workstoreLastAccessed[name] = _now();
-        return workstore[name];
+
+        _freeze(lookup);
+        setWorkstoreItem(name, lookup);
+        return lookup;
     }
     return false;
 };
@@ -391,7 +340,7 @@ P.buildImageCoordinateLookup = function (image) {
 // `buildAlphaTileSets` - creates a record of which pixels belong to which tile - used for manipulating alpha channel values. Resulting object will be cached in the store
 P.buildAlphaTileSets = function (tileWidth, tileHeight, gutterWidth, gutterHeight, offsetX, offsetY, areaAlphaLevels, image) {
 
-    const { cache, workstore, workstoreLastAccessed } = this;
+    const { cache } = this;
 
     if (!image) image = cache.source;
 
@@ -424,12 +373,10 @@ P.buildAlphaTileSets = function (tileWidth, tileHeight, gutterWidth, gutterHeigh
         if (offsetY < 0) offsetY = 0;
         if (offsetY >= aHeight) offsetY = aHeight - 1;
 
-        const name = `alphatileset-${iWidth}-${iHeight}-${tileWidth}-${tileHeight}-${gutterWidth}-${gutterHeight}-${offsetX}-${offsetY}`;
+        const name = `alphatileset-${iWidth}-${iHeight}-${tileWidth}-${tileHeight}-${gutterWidth}-${gutterHeight}-${offsetX}-${offsetY}`,
+            itemInWorkstore = getWorkstoreItem(name);
 
-        if (workstore[name]) {
-            workstoreLastAccessed[name] = _now();
-            return workstore[name];
-        }
+        if (itemInWorkstore) return itemInWorkstore;
 
         const tiles = [];
 
@@ -480,9 +427,10 @@ P.buildAlphaTileSets = function (tileWidth, tileHeight, gutterWidth, gutterHeigh
                 tiles.push(_freeze([].concat(hold)));
             }
         }
-        workstore[name] = _freeze(tiles);
-        workstoreLastAccessed[name] = _now();
-        return workstore[name];
+
+        _freeze(tiles);
+        setWorkstoreItem(name, tiles);
+        return tiles;
     }
     return false;
 };
@@ -490,7 +438,7 @@ P.buildAlphaTileSets = function (tileWidth, tileHeight, gutterWidth, gutterHeigh
 // `buildImageTileSets` - creates a record of which pixels belong to which tile - used for manipulating color channels values. Resulting object will be cached in the store
 P.buildImageTileSets = function (tileWidth, tileHeight, offsetX, offsetY, image) {
 
-    const { cache, workstore, workstoreLastAccessed } = this;
+    const { cache } = this;
 
     if (!image) image = cache.source;
 
@@ -512,12 +460,10 @@ P.buildImageTileSets = function (tileWidth, tileHeight, offsetX, offsetY, image)
         if (offsetY < 0) offsetY = 0;
         if (offsetY >= tileHeight) offsetY = tileHeight - 1;
 
-        const name = `simple-tileset-${iWidth}-${iHeight}-${tileWidth}-${tileHeight}-${offsetX}-${offsetY}`;
+        const name = `simple-tileset-${iWidth}-${iHeight}-${tileWidth}-${tileHeight}-${offsetX}-${offsetY}`,
+            itemInWorkstore = getWorkstoreItem(name);
 
-        if (workstore[name]) {
-            workstoreLastAccessed[name] = _now();
-            return workstore[name];
-        }
+        if (itemInWorkstore) return itemInWorkstore;
 
         const tiles = [];
 
@@ -542,8 +488,9 @@ P.buildImageTileSets = function (tileWidth, tileHeight, offsetX, offsetY, image)
                 if (hold.length) tiles.push(_freeze(hold));
             }
         }
-        workstore[name] = _freeze(tiles);
-        workstoreLastAccessed[name] = _now();
+
+        _freeze(tiles);
+        setWorkstoreItem(name, tiles);
         return tiles;
     }
     return false;
@@ -553,7 +500,7 @@ P.buildImageTileSets = function (tileWidth, tileHeight, offsetX, offsetY, image)
 // + Used by the `tile` filter, but separated out as the data it generates may have uses elsewhere
 P.buildGeneralTileSets = function (pointVals, tileWidth, tileHeight, tileRadius, offsetX, offsetY, angle, seed, image) {
 
-    const { cache, workstore, workstoreLastAccessed } = this;
+    const { cache } = this;
 
     if (!image) image = cache.source;
     const { width:iWidth, height:iHeight } = image;
@@ -610,27 +557,18 @@ P.buildGeneralTileSets = function (pointVals, tileWidth, tileHeight, tileRadius,
         if (req == POINTS_ARRAY) name += `-${pointVals.join(ARG_SPLITTER)}`;
         else if (req == RANDOM_POINTS) name += `-${pointVals}-${seed}`;
 
-        // To save time, previous invocations of the function store their end result - an Array of Arrays containing the index position of each pixel in the source image, assigned to each tile.
-        if (workstore[name]) {
+        const itemInWorkstore = getWorkstoreItem(name);
 
-            workstoreLastAccessed[name] = _now();
-            return workstore[name];
-        }
+        if (itemInWorkstore) return itemInWorkstore;
 
-        // Returning an empty array to the tile filter results in the filter taking no action beyond copying the input image data into the output image data.
-        if (req == RECT_GRID && tileW === 1 && tileH === 1) {
-
-            workstore[name] = [];
-            workstoreLastAccessed[name] = _now();
-            return [];
-        }
+        if (req == RECT_GRID && tileW === 1 && tileH === 1) return getOrAddWorkstoreItem(name);
 
         const coord = requestCoordinate(),
             origin = [offX, offY],
             test = [0, 0];
 
         let tiles = [],
-            points = [];
+            points;
 
         const referencePoints = [],
             neighbourPoints = [];
@@ -655,38 +593,34 @@ P.buildGeneralTileSets = function (pointVals, tileWidth, tileHeight, tileRadius,
             case RECT_GRID :
 
                 pointsName = `rect-grid-points-${iWidth}-${iHeight}-${tileW}-${tileH}-${offX}-${offY}`;
+                points = getWorkstoreItem(pointsName);
 
-                if (workstore[pointsName]) {
+                if (!points) {
 
-                    workstoreLastAccessed[pointsName] = _now();
-                    points = workstore[pointsName];
-                }
-                else {
+                    const newPoints = [];
 
                     // Generates a set of initial points in an overlarge grid (for square tiles)
                     for (y = offY - (iHeight * 2) + halfH, yz = offY + (iHeight * 2) + halfH; y < yz; y += tileH) {
 
                         for (x = offX - (iWidth * 2) + halfW, xz = offX + (iWidth * 2) + halfW; x < xz; x += tileW) {
 
-                            points.push(x, y);
+                            newPoints.push(x, y);
                         }
                     }
-                    workstoreLastAccessed[pointsName] = _now();
-                    workstore[pointsName] = _freeze(points);
-                    points = workstore[pointsName];
+
+                    _freeze(newPoints);
+                    points = getOrAddWorkstoreItem(pointsName, newPoints);
                 }
                 break;
 
             case HEX_GRID :
 
                 pointsName = `hex-grid-points-${iWidth}-${iHeight}-${tileR}-${offX}-${offY}`;
+                points = getWorkstoreItem(pointsName);
 
-                if (workstore[pointsName]) {
+                if (!points) {
 
-                    workstoreLastAccessed[pointsName] = _now();
-                    points = workstore[pointsName];
-                }
-                else {
+                    const newPoints = [];
 
                     // Generates a set of initial points in an overlarge grid (for hexagonal tiles)
                     counter = 0;
@@ -696,13 +630,13 @@ P.buildGeneralTileSets = function (pointVals, tileWidth, tileHeight, tileRadius,
 
                         for (x = offX - (iWidth * 2) + tileR + hexOffset, xz = offX + (iWidth * 2) + tileR; x < xz; x += doubleR) {
 
-                            points.push(x, y);
+                            newPoints.push(x, y);
                         }
                         counter++;
                     }
-                    workstoreLastAccessed[pointsName] = _now();
-                    workstore[pointsName] = _freeze(points);
-                    points = workstore[pointsName];
+
+                    _freeze(newPoints);
+                    points = getOrAddWorkstoreItem(pointsName, newPoints);
                 }
                 tileW = doubleR * 2;
                 tileH = hexDown * 2;
@@ -711,13 +645,11 @@ P.buildGeneralTileSets = function (pointVals, tileWidth, tileHeight, tileRadius,
             case RANDOM_POINTS :
 
                 pointsName = `random-points-${iWidth}-${iHeight}-${tileR}-${offX}-${offY}-${points}-${seed}`;
+                points = getWorkstoreItem(pointsName);
 
-                if (workstore[pointsName]) {
+                if (!points) {
 
-                    workstoreLastAccessed[pointsName] = _now();
-                    points = workstore[pointsName];
-                }
-                else {
+                    const newPoints = [];
 
                     // Generates a set of initial random points withing the given constraints
                     const rnd = this.getRandomNumbers({
@@ -731,11 +663,11 @@ P.buildGeneralTileSets = function (pointVals, tileWidth, tileHeight, tileRadius,
                         coord.zero().add([rnd[++rndCursor], rnd[++rndCursor]]).rotate(rnd[++rndCursor] * 360).rotate(ang).scalarMultiply(tileR);
 
                         [x, y] = coord;
-                        points.push(_round(x), _round(y));
+                        newPoints.push(_round(x), _round(y));
                     }
-                    workstoreLastAccessed[pointsName] = _now();
-                    workstore[pointsName] = _freeze(points);
-                    points = workstore[pointsName];
+
+                    _freeze(newPoints);
+                    points = getOrAddWorkstoreItem(pointsName, newPoints);
                 }
                 tileW = tileR;
                 tileH = tileR;
@@ -744,20 +676,15 @@ P.buildGeneralTileSets = function (pointVals, tileWidth, tileHeight, tileRadius,
             case POINTS_ARRAY :
 
                 pointsName = `defined-points-${iWidth}-${iHeight}-${tileR}-${pointVals}`;
+                points = getWorkstoreItem(pointsName);
 
-                if (workstore[pointsName]) {
+                if (!points) {
+                
+                    // User-generated points are not pre-processed. Note that the positioning of these points is relative to the offset coordinate values; users, when generating the point values, need to take this into account otherwise the end result may unexpectedly move towards (or beyond) the bottom-right part of the final image.
+                    const newPoints = [...pointVals];
 
-                    workstoreLastAccessed[pointsName] = _now();
-                    points = workstore[pointsName];
-                }
-                // User-generated points are not pre-processed. Note that the positioning of these points is relative to the offset coordinate values; users, when generating the point values, need to take this into account otherwise the end result may unexpectedly move towards (or beyond) the bottom-right part of the final image.
-                else {
-
-                    points.push(...pointVals);
-
-                    workstoreLastAccessed[pointsName] = _now();
-                    workstore[pointsName] = _freeze(points);
-                    points = workstore[pointsName];
+                    _freeze(newPoints);
+                    points = getOrAddWorkstoreItem(pointsName, newPoints);
                 }
 
                 tileW = tileR;
@@ -850,9 +777,9 @@ P.buildGeneralTileSets = function (pointVals, tileWidth, tileHeight, tileRadius,
         // Filter the tiles Array to remove undefined indexes, then stash the result in the workstore (for future quick-serve) and return the array.
         tiles = tiles.filter(t => t != null);
 
-        workstore[name] = _freeze(tiles);
-        workstoreLastAccessed[name] = _now();
-        return workstore[name];
+        _freeze(tiles);
+        setWorkstoreItem(name, tiles);
+        return tiles;
     }
     return [];
 };
@@ -860,19 +787,15 @@ P.buildGeneralTileSets = function (pointVals, tileWidth, tileHeight, tileRadius,
 // `buildHorizontalBlur` - creates an Array of Arrays detailing which pixels contribute to the horizontal part of each pixel's blur calculation. Resulting object will be cached in the store
 P.buildHorizontalBlur = function (grid, radius) {
 
-    const { workstore, workstoreLastAccessed } = this;
-
     if (!radius || !radius.toFixed || isNaN(radius)) radius = 0;
 
     const gridHeight = grid.length,
         gridWidth = grid[0].length;
 
-    const name = `blur-h-${gridWidth}-${gridHeight}-${radius}`;
+    const name = `blur-h-${gridWidth}-${gridHeight}-${radius}`,
+        itemInWorkstore = getWorkstoreItem(name);
 
-    if (workstore[name]) {
-        workstoreLastAccessed[name] = _now();
-        return workstore[name];
-    }
+    if (itemInWorkstore) return itemInWorkstore;
 
     const horizontalBlur = [];
 
@@ -891,27 +814,24 @@ P.buildHorizontalBlur = function (grid, radius) {
             horizontalBlur[(y * gridWidth) + x] = _freeze(cellsToProcess);
         }
     }
-    workstore[name] = _freeze(horizontalBlur);
-    workstoreLastAccessed[name] = _now();
-    return workstore[name];
+
+    _freeze(horizontalBlur);
+    setWorkstoreItem(name, horizontalBlur);
+    return horizontalBlur;
 };
 
 // `buildVerticalBlur` - creates an Array of Arrays detailing which pixels contribute to the vertical part of each pixel's blur calculation. Resulting object will be cached in the store
 P.buildVerticalBlur = function (grid, radius) {
-
-    const { workstore, workstoreLastAccessed } = this;
 
     if (!radius || !radius.toFixed || isNaN(radius)) radius = 0;
 
     const gridHeight = grid.length,
         gridWidth = grid[0].length;
 
-    const name = `blur-v-${gridWidth}-${gridHeight}-${radius}`;
+    const name = `blur-v-${gridWidth}-${gridHeight}-${radius}`,
+        itemInWorkstore = getWorkstoreItem(name);
 
-    if (workstore[name]) {
-        workstoreLastAccessed[name] = _now();
-        return workstore[name];
-    }
+    if (itemInWorkstore) return itemInWorkstore;
 
     const verticalBlur = [];
 
@@ -930,15 +850,16 @@ P.buildVerticalBlur = function (grid, radius) {
             verticalBlur[(y * gridWidth) + x] = _freeze(cellsToProcess);
         }
     }
-    workstore[name] = _freeze(verticalBlur);
-    workstoreLastAccessed[name] = _now();
-    return workstore[name];
+
+    _freeze(verticalBlur);
+    setWorkstoreItem(name, verticalBlur);
+    return verticalBlur;
 };
 
 // `buildMatrixGrid` - creates an Array of Arrays detailing which pixels contribute to each pixel's matrix calculation. Resulting object will be cached in the store
 P.buildMatrixGrid = function (mWidth, mHeight, mX, mY, image) {
 
-    const { cache, workstore, workstoreLastAccessed } = this;
+    const { cache } = this;
 
     if (!image) image = cache.source;
 
@@ -953,12 +874,10 @@ P.buildMatrixGrid = function (mWidth, mHeight, mX, mY, image) {
     if (mY == null || mY < 0) mY = 0;
     else if (mY >= mHeight) mY = mHeight - 1;
 
-    const name = `matrix-${iWidth}-${iHeight}-${mWidth}-${mHeight}-${mX}-${mY}`;
+    const name = `matrix-${iWidth}-${iHeight}-${mWidth}-${mHeight}-${mX}-${mY}`,
+        itemInWorkstore = getWorkstoreItem(name);
 
-    if (workstore[name]) {
-        workstoreLastAccessed[name] = _now();
-        return workstore[name];
-    }
+    if (itemInWorkstore) return itemInWorkstore;
 
     const dataLength = data.length,
         cellsTemplate = [],
@@ -993,9 +912,10 @@ P.buildMatrixGrid = function (mWidth, mHeight, mX, mY, image) {
             grid.push(_freeze(cell));
         }
     }
-    workstore[name] = _freeze(grid);
-    workstoreLastAccessed[name] = _now();
-    return workstore[name];
+
+    _freeze(grid);
+    setWorkstoreItem(name, grid);
+    return grid;
 };
 
 // `checkChannelLevelsParameters` - divide each channel into discrete sequences of pixels
@@ -1126,11 +1046,11 @@ P.processResults = function (store, incoming, ratio) {
 // `getGradientData` - create an imageData object containing the 256 values from a gradient that we require for doing filters work
 P.getGradientData = function (gradient) {
 
-    const { workstore, workstoreLastAccessed } = this;
-
     const name = `gradient-data-${gradient.name}`;
 
-    if (!workstore[name] || gradient.dirtyFilterIdentifier || gradient.animateByDelta) {
+    const itemInWorkstore = getWorkstoreItem(name);
+
+    if (!itemInWorkstore || gradient.dirtyFilterIdentifier || gradient.animateByDelta) {
 
         const mycell = requestCell();
 
@@ -1152,14 +1072,10 @@ P.getGradientData = function (gradient) {
 
         releaseCell(mycell);
 
-        workstore[name] = data;
+        return setAndReturnWorkstoreItem(name, data);
     }
 
-    if (workstore[name]) {
-        workstoreLastAccessed[name] = _now();
-        return workstore[name];
-    }
-    return [];
+    return itemInWorkstore || [];
 };
 
 P.transferDataUnchanged = function (oData, iData, len) {
@@ -4822,7 +4738,7 @@ P.theBigActionsObject = _freeze({
 
                     const swirlName = `swirl-${startX}-${startY}-${innerRadius}-${outerRadius}-${angle}-${ename}-${iWidth}-${iHeight}`;
 
-                    const swirlCoords = this.getOrAddWorkstore(swirlName);
+                    const swirlCoords = getOrAddWorkstoreItem(swirlName);
 
                     if (!swirlCoords.length) {
 

--- a/source/factory/palette.js
+++ b/source/factory/palette.js
@@ -206,7 +206,7 @@ S.colors = function (item) {
             }
         });
         this.colors = newCols;
-        this.markAsDirty();
+        this.dirtyPalette = true;
     }
 };
 
@@ -241,7 +241,7 @@ P.setEasingHelper = function (item) {
         this.easing = LINEAR;
         this.easingFunction = λfirstArg;
     }
-    this.markAsDirty();
+    this.dirtyPaletteData = true;
 };
 
 // The __colorSpace__ and __returnColorAs__ attributes get passed through to the Palette's Color object
@@ -273,7 +273,7 @@ S.colorSpace = function (item) {
                 this.colors[key].length = 0
                 this.colors[key].push(...this.factory[itm]);
             }
-            this.markAsDirty();
+            this.dirtyPalette = true;
         }
     }
 }
@@ -288,7 +288,7 @@ S.returnColorAs = function (item) {
 
         returnColorAs: item,
     });
-    this.markAsDirty();
+    this.dirtyPalette = true;
 }
 
 // __precision__ - a positive integer Number value between 0 and 50. If value is `0` (default) no easing will be applied to the gradient; values above 0 apply the easing to the gradient; higher values will give a quicker, but less precise, mapping.
@@ -299,7 +299,7 @@ S.precision = function (item) {
     if (item > 50) item = 50;
 
     this.precision = item;
-    this.markAsDirty();
+    this.dirtyPaletteData = true;
 };
 
 // __stops__ - Do nothing. The stops array needs to be kept private, its values set only via the `recalculateStopColors` function, which happens whenever the `dirtyPalette` attribute is set to true.
@@ -307,12 +307,6 @@ S.stops = λnull;
 
 
 // #### Prototype functions
-
-P.markAsDirty = function () {
-
-    this.dirtyPaletteData = true;
-    this.dirtyPalette = true;
-};
 
 // `getColorSpace` - returns the color factory's current colorSpace value
 P.getColorSpace = function () {
@@ -333,6 +327,7 @@ P.recalculateStopColors = function () {
     if (this.dirtyPalette) {
 
         this.dirtyPalette = false;
+        this.dirtyPaletteData = true;
 
         const { colors, stops, factory } = this;
 
@@ -387,7 +382,6 @@ P.updateColor = function (index, color) {
             index += SPACE;
             this.colors[index] = [...f[colorSpace]];
             this.dirtyPalette = true;
-            this.dirtyPaletteData = true;
         }
     }
 };
@@ -405,7 +399,6 @@ P.removeColor = function (index) {
             index += SPACE;
             delete this.colors[index];
             this.dirtyPalette = true;
-            this.dirtyPaletteData = true;
         }
     }
 };
@@ -597,6 +590,12 @@ P.addStopsToGradient = function (gradient, start, end, cycle) {
     }
 
     return gradient;
+};
+
+// `updateData` - used by code elsewhere to tell the palette to update its stop data
+P.updateData = function () {
+
+    this.dirtyPaletteData = true;
 };
 
 

--- a/source/factory/palette.js
+++ b/source/factory/palette.js
@@ -91,7 +91,6 @@ const Palette = function (items = Ωempty) {
     this.set(items);
 
     this.dirtyPalette = true;
-    this.dirtyPaletteData = true;
     return this;
 };
 

--- a/source/mixin/asset-advanced-functionality.js
+++ b/source/mixin/asset-advanced-functionality.js
@@ -223,10 +223,13 @@ export default function (P = Ωempty) {
                 if (gradientLastUpdated + choke < now) {
 
                     gradient.updateByDelta();
+
+                    if (gradient.cyclePalette) palette.dirtyPaletteData = true;
+
                     this.gradientLastUpdated = now;
                 }
 
-                if (palette.dirtyPalette) palette.recalculate();
+                if (palette.dirtyPalette) palette.recalculateStopColors();
 
                 const lg = colorEngine.createLinearGradient(0, 0, 255, 0);
 

--- a/source/mixin/asset-advanced-functionality.js
+++ b/source/mixin/asset-advanced-functionality.js
@@ -206,8 +206,6 @@ export default function (P = Ωempty) {
 
                 const {element, engine, width, height, colorEngine, gradient, choke, gradientLastUpdated } = this;
 
-                const palette = gradient.palette;
-
                 // Update the Canvas element's dimensions - this will also clear the canvas display
                 element.width = width;
                 element.height = height;
@@ -226,10 +224,6 @@ export default function (P = Ωempty) {
 
                     this.gradientLastUpdated = now;
                 }
-
-                palette.dirtyPaletteData = true;
-
-                if (palette.dirtyPalette) palette.recalculateStopColors();
 
                 const lg = colorEngine.createLinearGradient(0, 0, 255, 0);
 

--- a/source/mixin/asset-advanced-functionality.js
+++ b/source/mixin/asset-advanced-functionality.js
@@ -224,10 +224,10 @@ export default function (P = Ωempty) {
 
                     gradient.updateByDelta();
 
-                    if (gradient.cyclePalette) palette.dirtyPaletteData = true;
-
                     this.gradientLastUpdated = now;
                 }
+
+                palette.dirtyPaletteData = true;
 
                 if (palette.dirtyPalette) palette.recalculateStopColors();
 

--- a/source/mixin/styles.js
+++ b/source/mixin/styles.js
@@ -266,7 +266,6 @@ export default function (P = Ωempty) {
         if(item.type == T_PALETTE) {
 
             item.dirtyPalette = true;
-            item.dirtyPaletteData = true;
             this.palette = item;
         }
     };

--- a/source/mixin/styles.js
+++ b/source/mixin/styles.js
@@ -273,7 +273,11 @@ export default function (P = Ωempty) {
 
             this.paletteStart = item;
 
-            if(item < 0 || item > 999) this.paletteStart = (item > 500) ? 999 : 0;
+            if(item < 0 || item > 999) {
+
+                this.paletteStart = (item > 500) ? 999 : 0;
+            }
+            this.dirtyPaletteData = true;
         }
     };
     D.paletteStart = function (item) {
@@ -291,6 +295,7 @@ export default function (P = Ωempty) {
             }
 
             this.paletteStart = p;
+            this.dirtyPaletteData = true;
         }
     };
 
@@ -303,6 +308,7 @@ export default function (P = Ωempty) {
             this.paletteEnd = item;
 
             if (item < 0 || item > 999) this.paletteEnd = (item > 500) ? 999 : 0;
+            this.dirtyPaletteData = true;
         }
     };
 
@@ -321,6 +327,7 @@ export default function (P = Ωempty) {
             }
 
             this.paletteEnd = p;
+            this.dirtyPaletteData = true;
         }
     };
 
@@ -566,7 +573,16 @@ export default function (P = Ωempty) {
     P.getData = function (entity, cell) {
 
         // Step 1: see if the palette is dirty, from having colors added/deleted/changed
-        if(this.palette && this.palette.dirtyPalette) this.palette.recalculate();
+        if(this.palette) {
+
+            if (this.palette.dirtyPalette) this.palette.recalculateStopColors();
+
+            if (this.dirtyPaletteData) {
+
+                this.dirtyPaletteData = false;
+                this.palette.dirtyPaletteData = true;
+            }
+        }
 
         // Step 2: recalculate current start and end points
         this.cleanStyle(entity, cell);
@@ -654,15 +670,10 @@ export default function (P = Ωempty) {
         return BLANK;
     };
 
-// `addStopsToGradient` - internal function, called by the `buildStyle` function (which is overwritten by the Gradient and RadialGradient factories)
+// `addStopsToGradient` - internal function, called by the `buildStyle` function (which is overwritten by the various gradient factories)
     P.addStopsToGradient = function (gradient, start, stop, cycle) {
 
-        if (this.palette) {
-
-            this.dirtyFilterIdentifier = true;
-
-            return this.palette.addStopsToGradient(gradient, start, stop, cycle);
-        }
+        if (this.palette) return this.palette.addStopsToGradient(gradient, start, stop, cycle);
         return gradient;
     };
 

--- a/source/mixin/styles.js
+++ b/source/mixin/styles.js
@@ -263,7 +263,11 @@ export default function (P = Ωempty) {
 // `palette` - argument has to be a Palette object
     S.palette = function (item = Ωempty) {
 
-        if(item.type == T_PALETTE) this.palette = item;
+        if(item.type == T_PALETTE) {
+
+            this.palette = item;
+            this.dirtyPalette = true;
+        }
     };
 
 // `paletteStart` - argument must be a positive integer Number in the range 0 - 999
@@ -277,7 +281,7 @@ export default function (P = Ωempty) {
 
                 this.paletteStart = (item > 500) ? 999 : 0;
             }
-            this.dirtyPaletteData = true;
+            this.dirtyPalette = true;
         }
     };
     D.paletteStart = function (item) {
@@ -295,7 +299,7 @@ export default function (P = Ωempty) {
             }
 
             this.paletteStart = p;
-            this.dirtyPaletteData = true;
+            this.dirtyPalette = true;
         }
     };
 
@@ -308,7 +312,7 @@ export default function (P = Ωempty) {
             this.paletteEnd = item;
 
             if (item < 0 || item > 999) this.paletteEnd = (item > 500) ? 999 : 0;
-            this.dirtyPaletteData = true;
+            this.dirtyPalette = true;
         }
     };
 
@@ -327,8 +331,14 @@ export default function (P = Ωempty) {
             }
 
             this.paletteEnd = p;
-            this.dirtyPaletteData = true;
+            this.dirtyPalette = true;
         }
+    };
+
+    S.cyclePalette = function (item) {
+
+        this.cyclePalette = !!item;
+        this.dirtyPalette = true;
     };
 
 // `colors` - We can pass through an array of palette color arrays to the Palette object by setting it on the gradient-type styles object. Each palette array is in the form `[Number, String]` where:
@@ -573,15 +583,10 @@ export default function (P = Ωempty) {
     P.getData = function (entity, cell) {
 
         // Step 1: see if the palette is dirty, from having colors added/deleted/changed
-        if(this.palette) {
+        if(this.palette && this.dirtyPalette) {
 
-            if (this.palette.dirtyPalette) this.palette.recalculateStopColors();
-
-            if (this.dirtyPaletteData) {
-
-                this.dirtyPaletteData = false;
-                this.palette.dirtyPaletteData = true;
-            }
+            this.dirtyPalette = false;
+            this.palette.markAsDirty();
         }
 
         // Step 2: recalculate current start and end points

--- a/source/scrawl.js
+++ b/source/scrawl.js
@@ -52,7 +52,7 @@ export {
 export * as library from './core/library.js';
 export { seededRandomNumberGenerator } from './core/random-seed.js';
 export { makeSnippet } from './core/snippets.js';
-export { 
+export {
     setFilterMemoizationChoke,
     setWorkstoreLifetimeLength,
     setWorkstorePurgeChoke,

--- a/source/scrawl.js
+++ b/source/scrawl.js
@@ -52,6 +52,11 @@ export {
 export * as library from './core/library.js';
 export { seededRandomNumberGenerator } from './core/random-seed.js';
 export { makeSnippet } from './core/snippets.js';
+export { 
+    setFilterMemoizationChoke,
+    setWorkstoreLifetimeLength,
+    setWorkstorePurgeChoke,
+ } from './core/workstore.js';
 export {
     currentCorePosition,
     startCoreListeners,
@@ -85,7 +90,6 @@ export { makeDragZone } from './factory/drag-zone.js';
 export { makeElement } from './factory/element.js';
 export { makeEmitter } from './factory/emitter.js';
 export { makeFilter } from './factory/filter.js';
-export { setFilterMemoizationChoke } from './factory/filter-engine.js';
 export { makeForce } from './factory/particle-force.js';
 export { makeGradient } from './factory/gradient.js';
 export { makeGrid } from './factory/grid.js';


### PR DESCRIPTION
A PR to put the workstore code into its own module file. This allows other parts of the codebase to make use of the workstore, in addition to filter code.