### PR TITLE
Add a frame rate limit to animation objects

### DIFF
--- a/demo/canvas-050.html
+++ b/demo/canvas-050.html
@@ -32,6 +32,20 @@
     <div id="scaling-label" class="pink label">Scaling</div>
     <button class="pink controlItem" id="scaling" value="0">Add scaling</button>
 
+    <div class="green label">Max frames/second</div>
+    <div class="green">
+      <select class="controlItem" id="maxFrameRate">
+        <option value="120">120</option>
+        <option value="90">90</option>
+        <option value="60">60</option>
+        <option value="45">45</option>
+        <option value="30">30</option>
+        <option value="15">15</option>
+        <option value="5">5</option>
+        <option value="1">1</option>
+      </select>
+    </div>
+
   </div>
 
   <canvas 
@@ -49,6 +63,10 @@
       <li>Create and animate a Wheel entity, using delta and deltaConstraint objects</li>
       <li>Check that reverse and loop actions work as expected</li>
       <li>Check that scaling animation can be added to and deleted from the delta object</li>
+    </ul>
+    <p>Additionally:</p>
+    <ul>
+      <li>Change the frame rate; check that the displayed screen refresh frame rate does not exceed this value</li>
     </ul>
     <p>setDeltaValues() actions not yet tested: 'newString', 'update', 'reverse', 'add', 'multiply'</p>
     <p><b>Touch test:</b> not required</p>

--- a/demo/canvas-050.html
+++ b/demo/canvas-050.html
@@ -18,7 +18,7 @@
 
 <body>
   <h1><a href="index.html">Scrawl-canvas v8</a> - Canvas test 050</h1>
-  <h2>Manipulate artefact delta animation values</h2>
+  <h2>Manipulate artefact delta animation values; test animation maxFrameRate</h2>
 
   <div class="controls">
     <div class="yellow label">Constraint action</div>

--- a/demo/canvas-050.js
+++ b/demo/canvas-050.js
@@ -1,5 +1,5 @@
 // # Demo Canvas 050
-// Manipulate artefact delta animation values
+// Manipulate artefact delta animation values; test animation maxFrameRate
 
 // [Run code](../../demo/canvas-050.html)
 import * as scrawl from '../source/scrawl.js'

--- a/demo/canvas-050.js
+++ b/demo/canvas-050.js
@@ -148,9 +148,10 @@ const report = reportSpeed('#reportmessage');
 
 
 // Create the Display cycle animation
-scrawl.makeRender({
+const animation = scrawl.makeRender({
 
     name: 'demo-animation',
+    maxFrameRate: 120,
     target: canvas,
     afterShow: report,
 });
@@ -219,11 +220,29 @@ scrawl.addNativeListener('click', (e) => {
 
 }, '#scaling');
 
+// Setup form observer functionality
+scrawl.makeUpdater({
+
+    event: ['input', 'change'],
+    origin: '.controlItem',
+
+    target: animation,
+
+    useNativeListener: true,
+    preventDefault: true,
+
+    updates: {
+        maxFrameRate: ['maxFrameRate', 'int'],
+    },
+});
+
 // @ts-expect-error
 document.querySelector('#scaling').value = '0';
 document.querySelector('#scaling').innerHTML = 'Add scaling';
 // @ts-expect-error
 document.querySelector('#constraintAction').value = 'reverse';
+// @ts-expect-error
+document.querySelector('#maxFrameRate').value = '120';
 
 
 // #### Development and testing

--- a/demo/index.html
+++ b/demo/index.html
@@ -517,7 +517,7 @@
       <div class="no-padding"><img src="thumbs/canvas-050.webp" /></div>
       <div>
         <a href="canvas-050.html">Canvas 050</a>
-        Manipulate artefact delta animation values
+        Manipulate artefact delta animation values; test animation maxFrameRate
       </div>
 
       <div class="no-padding"><img src="thumbs/canvas-051.webp" /></div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -507,7 +507,7 @@
     <li><a href="demo/canvas-047.html">Canvas-047</a> Easing functions for Color and Tween factories</li>
     <li><a href="demo/canvas-048.html">Canvas-048</a> Display a filtered media stream</li>
     <li><a href="demo/canvas-049.html">Canvas-049</a> Conic gradients</li>
-    <li><a href="demo/canvas-050.html">Canvas-050</a> Manipulate artefact delta animation values</li>
+    <li><a href="demo/canvas-050.html">Canvas-050</a> Manipulate artefact delta animation values; test animation maxFrameRate</li>
     <li><a href="demo/canvas-051.html">Canvas-051</a> Line Spirals</li>
     <li><a href="demo/canvas-052.html">Canvas-052</a> Create and use a RawAsset object to modify an image asset</li>
     <li><a href="demo/canvas-053.html">Canvas-053</a> Display output from a Reaction-Diffusion asset</li>

--- a/source/core/animation-loop.js
+++ b/source/core/animation-loop.js
@@ -41,7 +41,7 @@ import { getDoAnimation, getResortBatchAnimations, setDoAnimation, setResortBatc
 
 import { releaseArray, requestArray } from '../factory/array-pool.js';
 
-import { _floor } from './shared-vars.js';
+import { _floor, _now } from './shared-vars.js';
 
 
 // Local constants
@@ -109,7 +109,19 @@ const animationLoop = () => {
 
     for (let i = 0, iz = animate_sorted.length; i < iz; i++) {
 
-        animate_sorted[i].fn();
+        const a = animate_sorted[i],
+            now = _now();
+
+        if (a.chokedAnimation) {
+
+            // Warning: magic number! `825` seems to allow the frame rate to reach the max frame rate; setting it to anything higher means the frame rate never reaches the max frame rate.
+            if (a.lastRun + (825 / a.maxFrameRate) < now) {
+
+                a.fn();
+                a.lastRun = now;
+            }
+        }
+        else a.fn();
     }
 
     if (getDoAnimation()) window.requestAnimationFrame(animationLoop);

--- a/source/factory/animation.js
+++ b/source/factory/animation.js
@@ -43,6 +43,9 @@ const Animation = function (items = Ωempty) {
     this.onRun = items.onRun || λnull;
     this.onHalt = items.onHalt || λnull;
     this.onKill = items.onKill || λnull;
+    this.maxFrameRate = items.maxFrameRate || 60;
+    this.lastRun = 0;
+    this.chokedAnimation = true;
 
     this.register();
 
@@ -73,6 +76,9 @@ const defaultAttributes = {
 // + Higher order Animations will be processed after lower order Animations.
 // + Animations with the same `order` value will be processed in the order in which they were defined in code.
     order: 1,
+
+// __maxFrameRate__ - positive integer Number. A frames-per-second choke to prevent animation running too fast.
+    maxFrameRate: 60,
 
 // __fn__ - the main function that the Animation object will run on each RequestAnimationFrame tick. This function __must return a Promise__.
     fn: null,

--- a/source/factory/render-animation.js
+++ b/source/factory/render-animation.js
@@ -83,6 +83,10 @@ const RenderAnimation = function (items = Ωempty) {
     this.onHalt = items.onHalt || λnull;
     this.onKill = items.onKill || λnull;
 
+    this.maxFrameRate = items.maxFrameRate || 60;
+    this.lastRun = 0;
+    this.chokedAnimation = true;
+
     // These attributes are specific to RenderAnimation
     this.target = target;
 
@@ -172,6 +176,9 @@ const defaultAttributes = {
 
 // __order__ - positive integer Number. Determines the order in which each animation object will be actioned during the Display cycle. Higher order animations will be processed after lower order animations.
     order: 1,
+
+// __maxFrameRate__ - positive integer Number. A frames-per-second choke to prevent animation running too fast.
+    maxFrameRate: 60,
 
 // __onRun__, __onHalt__, __onKill__
 //

--- a/source/scrawl.d.ts
+++ b/source/scrawl.d.ts
@@ -683,6 +683,7 @@ interface AnimationFactoryDeltaInputs extends BaseMixinDeltaInputs {}
 
 interface AnimationFactoryInputs extends BaseMixinInputs, AnimationFactoryDeltaInputs {
     order?: number;
+    maxFrameRate?: number;
     fn?: DefaultInputFunction;
     onRun?: DefaultInputFunction;
     onHalt?: DefaultInputFunction;
@@ -2183,6 +2184,7 @@ interface RenderFactoryInputs extends BaseMixinInputs, RenderFactoryDeltaInputs 
     afterShow?: DefaultInputFunction;
     commence?: DefaultInputFunction;
     error?: DefaultInputFunction;
+    maxFrameRate?: number;
     onHalt?: DefaultInputFunction;
     onKill?: DefaultInputFunction;
     onRun?: DefaultInputFunction;


### PR DESCRIPTION
SC runs as fast as the browser's Request Animation Frame functionality (plus webpage display requirements) allows. However, where 60fps used to be the general animation frame rate limit, we now live in a world where browsers and display equipment conspire to run at up to 120fps. This can lead to SC animations doubling in speed, which may not be the desired outcome.

This PR introduces the concept of `maxFrameRate` to SC animation objects, and updates demo `canvas-050` to test that the new functionality works.