### PR TITLE
Fix final major EnhancedLabel bug

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,9 +1,5 @@
-The MIT License (MIT)
-
-Permission is hereby granted, free of charge, to any person ("You") obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS, CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-If You choose to offer this Software, in whole or part, as a component or product in a jurisdiction requiring lifecycle duty of care You agree to indemnify, defend, and hold each contributor to the Software (the "Contributors") harmless for any liability incurred by, or claims asserted against, such Contributors by reason of Your actions in such a jurisdiction.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Welcome to the Scrawl-canvas Library
-Version: `8.12.0 - 12 January 2024` 
+Version: `8.13.0 - 27 April 2024` 
 
 Scrawl-canvas website: [scrawl-v8.rikweb.org.uk](https://scrawl-v8.rikweb.org.uk).
 + learning materials: [scrawl-v8.rikweb.org.uk/learn](https://scrawl-v8.rikweb.org.uk/learn).
@@ -58,7 +58,7 @@ There are three main ways to include Scrawl-canvas in your project:
 2. Unzip the file to a folder in your project. 
 3. Import the library into the script code where you will be using it.
 
-Alternatively, a zip package of the v8.12.0 files can be downloaded from this link: [scrawl.rikweb.org.uk/downloads/scrawl-canvas_8-12-0.zip](https://scrawl.rikweb.org.uk/downloads/scrawl-canvas_8-12-0.zip) - that package only includes the minified file.
+Alternatively, a zip package of the v8.13.0 files can be downloaded from this link: [scrawl.rikweb.org.uk/downloads/scrawl-canvas_8-13-0.zip](https://scrawl.rikweb.org.uk/downloads/scrawl-canvas_8-13-0.zip) - that package only includes the minified file.
 
 ```html
 <!-- Hello world -->
@@ -69,7 +69,7 @@ Alternatively, a zip package of the v8.12.0 files can be downloaded from this li
 </head>
 <body>
     
-    <canvas id="mycanvas"></canvas>
+    <canvas id="my-canvas"></canvas>
 
     <!-- The library is entirely modular and needs to be imported into a module script -->
     <script type="module">
@@ -77,20 +77,16 @@ Alternatively, a zip package of the v8.12.0 files can be downloaded from this li
         import * as scrawl from './relative-or-absolute/path/to/scrawl-canvas/min/scrawl.js';
 
         // Get a handle to the canvas element
-        let canvas = scrawl.library.canvas.mycanvas;
+        let canvas = scrawl.findCanvas('my-canvas');
 
         // Setup the scene to be displayed in the canvas
-        scrawl.makePhrase({
+        scrawl.makeLabel({
 
             name: 'hello',
+            start: [20, 20],
+
             text: 'Hello, World!',
-
-            width: '100%',
-
-            startX: 20,
-            startY: 20,
-
-            font: 'bold 40px Garamond, serif',
+            fontString: 'bold 40px Garamond, serif',
         });
 
         // Render the canvas scene once
@@ -106,7 +102,7 @@ Alternatively, a zip package of the v8.12.0 files can be downloaded from this li
 This will pull the requested npm package directly into your web page:
 ```html
 <script type="module">
-    import * as scrawl from 'https://unpkg.com/scrawl-canvas@8.12.0';
+    import * as scrawl from 'https://unpkg.com/scrawl-canvas@8.13.0';
     [...]
 </script>
 ```
@@ -133,7 +129,7 @@ import * as scrawl from 'scrawl-canvas';
 After forking this repo down to your local machine, `cd` into the scrawl-canvas folder, run `yarn install` or `npm install` (for the local build toolchain - the library itself has no external dependencies) and start a local server.
 
 ```sh
-$> cd ./path/to/Scrawl-canvas
+$> cd ./path/to/Scrawl-canvas/folder
 $> yarn install
 $> yarn dev
 ```
@@ -141,9 +137,9 @@ $> yarn dev
 ### Testing
 The code base does not include any ___unit testing___ frameworks. Instead, we rely on a set of Demo tests which allow us to perform ___integration testing___ and ___user interface testing___.
 
-Why this approach? Because most of the Scrawl-canvas functionality revolves around various forms of animation, which requires visual inspection of the Demo tests to check that the canvas display - and thus, by inference, the underlying code - performs as expected.
+Why this approach? Because most of the Scrawl-canvas functionality revolves around various forms of user interaction and animation, which requires visual inspection of the Demo tests to check that the canvas display - and thus, by inference, the underlying code - performs as expected.
 
-Most Demos include some form of user interaction, which allows us to test specific aspects of the code base.
+Demos that include user interaction allow us to test specific aspects of the code base.
 
 #### Linting
 The tool chain includes the [ESLint](https://eslint.org/) package to impose some basic checks on code. We use the default checks supplied by the package (as indicated in the [rules documentation page](https://eslint.org/docs/latest/rules)). To run the linter:

--- a/demo/dom-001.html
+++ b/demo/dom-001.html
@@ -54,7 +54,7 @@
 
   <p>... or if using the remote CDN version:</p>
 
-  <h3><b>import</b> * as scrawl from 'https://unpkg.com/scrawl-canvas@8.12.0';</h3>
+  <h3><b>import</b> * as scrawl from 'https://unpkg.com/scrawl-canvas@8.13.0';</h3>
 
   <p>The import doesn't need to be called <span class="scrawl-code">'scrawl'</span> - it can be whatever the user prefers.</p>
 

--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
     <li>Makes the canvas both accessible, and interactive - including the ability to easily track user interactions with different parts of the canvas.</li>
   </ul>
 
-  <p>These test demos and documentation are for <b>Scrawl-canvas v8.12.0</b></p>
+  <p>These test demos and documentation are for <b>Scrawl-canvas v8.13.0</b></p>
 
   <h4>Download and installation</h4>
   <p><a href="https://github.com/KaliedaRik/Scrawl-canvas">See GitHub for details</a> on how to add Scrawl-canvas to a project.</p>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "scrawl-canvas",
-  "version": "8.12.0",
-  "description": "Version 8.12.0 - 12 January 2024",
+  "version": "8.13.0",
+  "description": "Version 8.13.0 - 27 April 2024",
   "main": "./min/scrawl.js",
   "type": "module",
   "types": "./source/scrawl.d.ts",

--- a/source/factory/enhanced-label.js
+++ b/source/factory/enhanced-label.js
@@ -1666,7 +1666,13 @@ P.positionTextUnitsAlongPath = function () {
                 offsetY = this.getTextOffset(temp, height);
 
                 currentLen += handleY;
-                if (currentLen >= length) currentLen -= length;
+                if (currentLen >= length) {
+
+                    currentLen -= length;
+                    unit.lineStart = true;
+                }
+                else unit.lineStart = false;
+
                 currentPos = currentLen / length;
 
                 unit.pathData = layoutTemplate.getPathPositionData(currentPos, true);
@@ -1705,7 +1711,13 @@ P.positionTextUnitsAlongPath = function () {
                 offsetY = this.getTextOffset(temp, height);
 
                 currentLen += handleX;
-                if (currentLen >= length) currentLen -= length;
+                if (currentLen >= length) {
+
+                    currentLen -= length;
+                    unit.lineStart = true;
+                }
+                else unit.lineStart = false;
+
                 currentPos = currentLen / length;
 
                 unit.pathData = layoutTemplate.getPathPositionData(currentPos, true);
@@ -2243,7 +2255,7 @@ P.positionTextDecoration = function () {
         includeUnderline, underlineStyle, underlineOffset, underlineWidth,
         includeOverline, overlineStyle, overlineOffset, overlineWidth,
         includeHighlight, highlightStyle,
-        localStyle, realisedStyle, realisedOffset, realisedWidth;
+        lineStart, localStyle, realisedStyle, realisedOffset, realisedWidth;
 
     const underlineOut = requestArray();
     const underlineBack = requestArray();
@@ -2292,6 +2304,7 @@ P.positionTextDecoration = function () {
                 ({
                     boxData,
                     charType,
+                    lineStart,
                     localStyle,
                     style,
                 } = unit);
@@ -2350,6 +2363,13 @@ P.positionTextDecoration = function () {
 
                             // TextUnits that are all single chars will style spaces
                             if (!breakTextOnSpaces) {
+
+                                if (lineStart) {
+console.log('lineStart detected')
+                                    buildUnderline();
+                                    buildOverline();
+                                    buildHighlight();
+                                }
 
                                 if (localStyle.includeUnderline) {
 
@@ -3398,6 +3418,8 @@ U.defs = {
     startRotation: 0,
     localStyle: null,
 
+    lineStart: false,
+
     len: 0,
     height: 0,
     kernOffset: 0,
@@ -3519,6 +3541,7 @@ U.set = function (items = Ωempty) {
                 case 'index' :
                 case 'kernOffset' :
                 case 'len' :
+                case 'lineStart' :
                 case 'localAlignment' :
                 case 'localStyle' :
                 case 'pathData' :

--- a/source/factory/enhanced-label.js
+++ b/source/factory/enhanced-label.js
@@ -2365,7 +2365,7 @@ P.positionTextDecoration = function () {
                             if (!breakTextOnSpaces) {
 
                                 if (lineStart) {
-console.log('lineStart detected')
+
                                     buildUnderline();
                                     buildOverline();
                                     buildHighlight();

--- a/source/scrawl.js
+++ b/source/scrawl.js
@@ -1,28 +1,6 @@
 // # Scrawl-canvas
 //
-// #### Version 8.12.0 - 12 January 2024
-//
-// ---------------------------------------------------------------------------------
-// The MIT License (MIT)
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
-// ---------------------------------------------------------------------------------
+// #### Version 8.13.0 - 27 April 2024
 
 
 // ## Initialize Scrawl-canvas


### PR DESCRIPTION
Fixes an annoying bug where EL text-along-a-path styling sometimes included lines between the end of the line and its beginning.

Also: wherever `v8.12.0` appears in file documentation, have updated it to `v8.13.0` - in anticipation of releasing the latest version to production on (or soon after) 27 April.

Another also: updated the example code in `README.md` to use a Label entity, removing the previously used Phrase entity code.