### PR TITLE
Remove unnecessary mixin includes from the DOM mixin

### DIFF
--- a/demo/canvas-009.html
+++ b/demo/canvas-009.html
@@ -112,7 +112,7 @@
       <li>Kill and resurrect a Pattern style to make sure it removes itself entirely from the Scrawl-canvas system, and cleanly recreate itself from saved packet</li>
     </ul>
 
-    <p><b>To note:</b> (fixed in latest Chrome - July 24?) this test runs very slowly on Chrome-based browsers, but as expected on Firefox/Safari. The issue is entirely around the canvas context drawImage() function. One possibility is that in Chrome, if the source and destination canvas/contexts are of different sizes such that one gets stored in in CPU and the other in GPU, then the speed of the drawImage copy gets badly degraded. Chrome appears to use drawImage() internally to create patterns, which can lead to painfully slow render speeds.</p>
+    <p><b>To note:</b> this test runs very slowly on Chrome-based browsers, but as expected on Firefox/Safari. The issue is entirely around the canvas context drawImage() function. One possibility is that in Chrome, if the source and destination canvas/contexts are of different sizes such that one gets stored in in CPU and the other in GPU, then the speed of the drawImage copy gets badly degraded. Chrome appears to use drawImage() internally to create <b>patterns</b>, which can lead to painfully slow render speeds? Although: see test demo Canvas-035 which employs similar patterns but runs at the expected speed in Chrome ... the mystery deepens!</p>
 
     <p><b>Touch test:</b> should work as expected - but dragging a finger from one block to another may lead to web page navigation being blocked by browser</p>
 

--- a/demo/dom-002.js
+++ b/demo/dom-002.js
@@ -18,7 +18,10 @@ const name = (n) => `${namespace}-${n}`;
 
 // Give the stack element some depth
 stack.set({
-    perspectiveZ: 1200
+    perspectiveZ: 1200,
+    css: {
+        overflow: 'hidden',
+    },
 });
 
 
@@ -65,6 +68,7 @@ mimic.set({
     addOwnHandleToMimic: false,
     addOwnOffsetToMimic: true,
     addOwnRotationToMimic: false,
+    order: 1,
 });
 
 
@@ -73,6 +77,7 @@ const pivot = scrawl.findElement('mypivot');
 pivot.set({
     pivot: 'myelement',
     lockTo: 'pivot',
+    order: 1,
 });
 
 

--- a/demo/dom-003.js
+++ b/demo/dom-003.js
@@ -25,7 +25,10 @@ const hitGroup = scrawl.makeGroup({
 
 // TODO: we need perspectiveZ (CSS perspective) to be picked up from CSS setting in html file. The code where this is handled is in mixin/dom.js lines 355 onwards. Currently is a known issue (low priority)
 stack.set({
-    perspectiveZ: 1200
+    perspectiveZ: 1200,
+    css: {
+        overflow: 'hidden',
+    },
 });
 
 // Generate new (DOM) element artefacts and add them to the stack via our new group

--- a/demo/dom-009.html
+++ b/demo/dom-009.html
@@ -21,6 +21,7 @@
 
     #mystack {
       touch-action: none;
+      margin: 0 auto;
     }
   </style>
 </head>

--- a/demo/dom-009.js
+++ b/demo/dom-009.js
@@ -14,6 +14,9 @@ const artefact = scrawl.library.artefact,
 stack.set({
     width: 600,
     height: 600,
+    css: {
+        overflow: 'hidden',
+    },
 });
 
 

--- a/demo/dom-013.html
+++ b/demo/dom-013.html
@@ -55,11 +55,11 @@
     <div class="yellow">&nbsp;</div>
 
     <div class="yellow label">Pitch</div>
-    <div class="yellow"><input class="controlItem" id="pitch" type="range" value="0" min="0" max="360" step="1" /></div>
+    <div class="yellow"><input class="controlItem" id="pitch" type="range" value="10" min="0" max="360" step="1" /></div>
     <div class="yellow">&nbsp;</div>
 
     <div class="yellow label">Yaw</div>
-    <div class="yellow"><input class="controlItem" id="yaw" type="range" value="0" min="0" max="360" step="1" /></div>
+    <div class="yellow"><input class="controlItem" id="yaw" type="range" value="15" min="0" max="360" step="1" /></div>
     <div class="yellow">&nbsp;</div>
 
     <div class="yellow label">Scale</div>

--- a/demo/dom-013.js
+++ b/demo/dom-013.js
@@ -32,6 +32,8 @@ canvas.set({
     handle: ['center', 'center'],
     trackHere: 'local',
     offsetZ: 150,
+    pitch: 10,
+    yaw: 15,
 });
 
 
@@ -164,8 +166,8 @@ initializeDomInputs([
     ['input', 'offset_xAbsolute', '0'],
     ['input', 'offset_yAbsolute', '0'],
     ['input', 'roll', '0'],
-    ['input', 'pitch', '0'],
-    ['input', 'yaw', '0'],
+    ['input', 'pitch', '10'],
+    ['input', 'yaw', '15'],
     ['input', 'scale', '1'],
 ]);
 

--- a/source/factory/canvas.js
+++ b/source/factory/canvas.js
@@ -46,6 +46,9 @@ import { releaseArray, requestArray } from '../helper/array-pool.js';
 import baseMix from '../mixin/base.js';
 import domMix from '../mixin/dom.js';
 import displayMix from '../mixin/display-shape.js';
+import hiddenElementsMix from '../mixin/hidden-dom-elements.js';
+import anchorMix from '../mixin/anchor.js';
+import buttonMix from '../mixin/button.js';
 
 // Shared constants
 import { _2D, _computed, ABSOLUTE, ARIA_HIDDEN, ARIA_LIVE, CANVAS, DATA_TAB_ORDER, DATA_SCRAWL_GROUP, DISPLAY_P3, DIV, DOWN, ENTER, IMG, LEAVE, MOVE, NAME, NONE, PC100, PC50, POLITE, RELATIVE, ROLE, ROOT, SRGB, SUBSCRIBE, T_CANVAS, T_STACK, TRUE, UP, ZERO_STR } from '../helper/shared-vars.js';
@@ -84,6 +87,7 @@ const Canvas = function (items = Ωempty) {
     this.dirtyPerspective = true;
 
     this.initializeDomLayout(items);
+    this.modifyConstructorInputForAnchorButton(items);
 
     this.set(this.defs);
 
@@ -268,6 +272,9 @@ P.isAsset = false;
 baseMix(P);
 domMix(P);
 displayMix(P);
+hiddenElementsMix(P);
+anchorMix(P);
+buttonMix(P);
 
 
 // #### Canvas attributes
@@ -643,6 +650,12 @@ P.cleanDimensionsAdditionalActions = function () {
     this.dirtyDomDimensions = true;
     this.dirtyDisplayShape = true;
     this.dirtyDisplayArea = true;
+};
+
+// `prepareStampTabsHelper` is defined in the `mixin/hidden-dom-elements.js` file - handles updates to anchor and button objects
+P.prepareStampAdditionalActions = function () {
+
+    this.prepareStampTabsHelper();
 };
 
 // `addCell` - add a Cell object to the wrapper's cells Array; argument can be the Cell's name-String, or the Cell object itself

--- a/source/factory/stack.js
+++ b/source/factory/stack.js
@@ -379,6 +379,7 @@ P.show = function () {
 // `render`
 P.render = function () {
 
+    this.clear();
     this.compile();
     this.show();
 };

--- a/source/mixin/dom.js
+++ b/source/mixin/dom.js
@@ -32,12 +32,12 @@ import pivotMix from './pivot.js';
 import mimicMix from './mimic.js';
 import pathMix from './path.js';
 // Question: do DOM elements really need additional anchors and buttons?
-import hiddenElementsMix from '../mixin/hidden-dom-elements.js';
-import anchorMix from './anchor.js';
-import buttonMix from './button.js';
+// import hiddenElementsMix from '../mixin/hidden-dom-elements.js';
+// import anchorMix from './anchor.js';
+// import buttonMix from './button.js';
 
 // Shared constants
-import { _entries, _isArray, _isFinite, _round, ABSOLUTE, ARIA_HIDDEN, BORDER_BOX, CORNER_LABELS, CORNER_SELECTOR, DIV, MIMIC, MOUSE, PARTICLE, PATH, PC0, PC100, PIVOT, SPACE, T_STACK, TRUE, ZERO_STR } from '../helper/shared-vars.js'
+import { _entries, _isArray, _isFinite, _round, ABSOLUTE, ARIA_HIDDEN, BORDER_BOX, CORNER_LABELS, CORNER_SELECTOR, DIV, MIMIC, MOUSE, PARTICLE, PATH, PC0, PC100, PIVOT, SPACE, T_CANVAS, T_STACK, TRUE, ZERO_STR } from '../helper/shared-vars.js'
 
 // Local constants
 const BOTTOMLEFT = 'bottomLeft',
@@ -62,9 +62,9 @@ export default function (P = Ωempty) {
     pivotMix(P);
     mimicMix(P);
     pathMix(P);
-    hiddenElementsMix(P);
-    anchorMix(P);
-    buttonMix(P);
+    // hiddenElementsMix(P);
+    // anchorMix(P);
+    // buttonMix(P);
 
 
 // #### Shared attributes
@@ -355,7 +355,7 @@ export default function (P = Ωempty) {
 // + TODO - there's a lot of improvements we can do here - the aim should be to create the wrapper object and update the objects DOM element's style and dimensions attributes - specifically shifting `position` from "static" to "absolute" - in a way that does not disturb the page view in any way whatsoever (pixel-perfect!) so website visitors are completely unaware that the work has taken place
     P.initializeDomLayout = function (items) {
 
-        this.modifyConstructorInputForAnchorButton(items);
+        // this.modifyConstructorInputForAnchorButton(items);
 
         const el = items.domElement;
 
@@ -821,9 +821,11 @@ export default function (P = Ωempty) {
 
         if (this.dirtyPathObject) this.cleanPathObject();
 
-        // `prepareStampTabsHelper` is defined in the `mixin/hidden-dom-elements.js` file - handles updates to anchor and button objects
-        this.prepareStampTabsHelper();
+        this.prepareStampAdditionalActions();
     };
+
+// `prepareStampAdditionalActions` - Canvas artefacts need to perform additional stamp actions around button and anchor hidden elements, but this is not relevant to Stack or Element artefacts
+    P.prepareStampAdditionalActions = λnull;
 
 // `stamp` - builds a set of Strings which can then be applied to the DOM wrapper's element's `style` attribute.
 // + The functionality for performing the update is defined in the [document](../core/document.html) module's `domShow` function, which will be called for each DOM-based artefact during the 'show' stage of the Display cycle

--- a/source/mixin/dom.js
+++ b/source/mixin/dom.js
@@ -31,13 +31,11 @@ import deltaMix from './delta.js';
 import pivotMix from './pivot.js';
 import mimicMix from './mimic.js';
 import pathMix from './path.js';
-// Question: do DOM elements really need additional anchors and buttons?
-// import hiddenElementsMix from '../mixin/hidden-dom-elements.js';
-// import anchorMix from './anchor.js';
-// import buttonMix from './button.js';
+
 
 // Shared constants
 import { _entries, _isArray, _isFinite, _round, ABSOLUTE, ARIA_HIDDEN, BORDER_BOX, CORNER_LABELS, CORNER_SELECTOR, DIV, MIMIC, MOUSE, PARTICLE, PATH, PC0, PC100, PIVOT, SPACE, T_CANVAS, T_STACK, TRUE, ZERO_STR } from '../helper/shared-vars.js'
+
 
 // Local constants
 const BOTTOMLEFT = 'bottomLeft',
@@ -62,9 +60,6 @@ export default function (P = Ωempty) {
     pivotMix(P);
     mimicMix(P);
     pathMix(P);
-    // hiddenElementsMix(P);
-    // anchorMix(P);
-    // buttonMix(P);
 
 
 // #### Shared attributes
@@ -354,8 +349,6 @@ export default function (P = Ωempty) {
 // + Used by factory constructors to help wrap DOM elements in a Stack, Canvas or Element wrapper
 // + TODO - there's a lot of improvements we can do here - the aim should be to create the wrapper object and update the objects DOM element's style and dimensions attributes - specifically shifting `position` from "static" to "absolute" - in a way that does not disturb the page view in any way whatsoever (pixel-perfect!) so website visitors are completely unaware that the work has taken place
     P.initializeDomLayout = function (items) {
-
-        // this.modifyConstructorInputForAnchorButton(items);
 
         const el = items.domElement;
 


### PR DESCRIPTION
The DOM mixin included the following code:
```
import hiddenElementsMix from '../mixin/hidden-dom-elements.js';
import anchorMix from '../mixin/anchor.js';
import buttonMix from '../mixin/button.js';
```

But these mixins are only relevant to Canvas artefacts, not Stack or Element artefacts. So they've been moved to the Canvas factory.

Note: initial testing seems fine, but requires more thorough testing across browsers before merging into v8-dev.

(Also: noticed the Chrome bug affecting test demo Canvas-009 is back. Added a note to the test)