### PR TITLE
Use requestAnimationFrame timestamp

### DIFF
--- a/source/core/animation-loop.js
+++ b/source/core/animation-loop.js
@@ -106,7 +106,7 @@ const animationLoop = (timestamp) => {
 export const startCoreAnimationLoop = () => {
 
     setDoAnimation(true);
-    animationLoop();
+    window.requestAnimationFrame(animationLoop);
 };
 
 // `Exported function` (modules and scrawl object). Halt the RAF function

--- a/source/core/animation-loop.js
+++ b/source/core/animation-loop.js
@@ -16,7 +16,7 @@ import { getDoAnimation, getResortBatchAnimations, setDoAnimation, setResortBatc
 import { releaseArray, requestArray } from '../helper/array-pool.js';
 
 // Shared constants
-import { _floor, _now } from '../helper/shared-vars.js';
+import { _floor } from '../helper/shared-vars.js';
 
 // Local constants
 const animate_sorted = [];
@@ -75,7 +75,7 @@ const sortAnimations = () => {
 };
 
 // The __requestAnimationFrame__ function
-const animationLoop = () => {
+const animationLoop = (timestamp) => {
 
     if (getResortBatchAnimations()) {
 
@@ -89,13 +89,11 @@ const animationLoop = () => {
 
         if (a.chokedAnimation) {
 
-            const now = _now();
-
             // Warning: magic number! `825` seems to allow the frame rate to reach the max frame rate; setting it to anything higher means the frame rate never reaches the max frame rate.
-            if (a.lastRun + (825 / a.maxFrameRate) < now) {
+            if (a.lastRun + (825 / a.maxFrameRate) < timestamp) {
 
                 a.fn();
-                a.lastRun = now;
+                a.lastRun = timestamp;
             }
         }
         else a.fn();


### PR DESCRIPTION
Don't know if there was a reason for it, but struck me as odd that the library was calling `Date.now`.  Inside of the loop struck me s odder even(as the time is unlikely to change over each iteration.)

---

requestionAnimationFrame callbacks receive a `DOMHighResTimeStamp` timestamp.

See: https://developer.mozilla.org/en-US/docs/Web/API/Window/requestAnimationFrame